### PR TITLE
Update vst-install-rhel.sh

### DIFF
--- a/install/vst-install-rhel.sh
+++ b/install/vst-install-rhel.sh
@@ -27,7 +27,7 @@ software="nginx awstats bc bind bind-libs bind-utils clamav-server clamav-update
     php-mcrypt phpMyAdmin php-mysql php-pdo phpPgAdmin php-pgsql php-soap
     php-tidy php-xml php-xmlrpc postgresql postgresql-contrib
     postgresql-server proftpd roundcubemail rrdtool rsyslog screen
-    spamassassin sqlite sudo tar telnet unzip vesta vesta-ioncube vesta-nginx
+    spamassassin sqlite sudo sysstat tar telnet unzip vesta vesta-ioncube vesta-nginx
     vesta-php vesta-softaculous vim-common vsftpd webalizer which zip"
 
 # Fix for old releases


### PR DESCRIPTION
Added sysstat package installation on $software variable. It is used by the v-list-sys-disk-status script.
This package installation fixes the error:
--------------------------------------------------------------------------
/usr/local/vesta/bin/v-list-sys-disk-status: line 29: iostat: command not found
--------------------------------------------------------------------------